### PR TITLE
Allow for images from network requests

### DIFF
--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -5,19 +5,19 @@ import 'package:image_size_getter/file_input.dart';
 
 void main(List<String> arguments) async {
   final file = File('asset/IMG_20180908_080245.jpg');
-  final size = ImageSizeGetter.getSize(FileInput(file));
+  final size = await ImageSizeGetter.getSize(FileInput(file));
   print('jpg = $size');
 
   final pngFile = File('asset/ic_launcher.png');
-  final pngSize = ImageSizeGetter.getSize(FileInput(pngFile));
+  final pngSize = await ImageSizeGetter.getSize(FileInput(pngFile));
   print('png = $pngSize');
 
   final webpFile = File('asset/demo.webp');
-  final webpSize = ImageSizeGetter.getSize(FileInput(webpFile));
+  final webpSize = await ImageSizeGetter.getSize(FileInput(webpFile));
   print('webp = $webpSize');
 
   final gifFile = File('asset/dialog.gif');
-  final gifSize = ImageSizeGetter.getSize(FileInput(gifFile));
+  final gifSize = await ImageSizeGetter.getSize(FileInput(gifFile));
   print('gif = $gifSize');
 
   // errorExample();

--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:image_size_getter/image_size_getter.dart';
 import 'package:image_size_getter/file_input.dart';
+import 'package:image_size_getter/src/core/network_input.dart';
 
 void main(List<String> arguments) async {
   final file = File('asset/IMG_20180908_080245.jpg');
@@ -19,6 +20,11 @@ void main(List<String> arguments) async {
   final gifFile = File('asset/dialog.gif');
   final gifSize = await ImageSizeGetter.getSize(FileInput(gifFile));
   print('gif = $gifSize');
+
+  final jpegNetworkFile = NetworkInput(
+      'https://images.unsplash.com/photo-1603744837416-bcffee8f5f8e');
+  final jpegNetworkSize = await ImageSizeGetter.getSize(jpegNetworkFile);
+  print('jpeg network = $jpegNetworkSize');
 
   // errorExample();
 }

--- a/library/lib/file_input.dart
+++ b/library/lib/file_input.dart
@@ -9,16 +9,16 @@ class FileInput extends ImageInput {
   FileInput(this.file);
 
   @override
-  List<int> getRange(int start, int end) {
+  Future<List<int>> getRange(int start, int end) async {
     final utils = FileUtils(file);
     return utils.getRangeSync(start, end);
   }
 
   @override
-  int get length => file.lengthSync();
+  Future<int> get length async => file.lengthSync();
 
   @override
-  bool exists() {
+  Future<bool> exists() async {
     return file != null && file.existsSync();
   }
 }

--- a/library/lib/image_size_getter.dart
+++ b/library/lib/image_size_getter.dart
@@ -1,3 +1,4 @@
 export 'src/core/size.dart';
 export 'src/core/memory_input.dart';
 export 'src/image_size_getter.dart';
+export 'src/core/network_input.dart';

--- a/library/lib/src/core/input.dart
+++ b/library/lib/src/core/input.dart
@@ -1,9 +1,9 @@
 abstract class ImageInput {
   const ImageInput();
 
-  int get length;
+  Future<int> get length;
 
-  List<int> getRange(int start, int end);
+  Future<List<int>> getRange(int start, int end);
 
-  bool exists();
+  Future<bool> exists();
 }

--- a/library/lib/src/core/memory_input.dart
+++ b/library/lib/src/core/memory_input.dart
@@ -11,15 +11,15 @@ class MemoryInput extends ImageInput {
   }
 
   @override
-  List<int> getRange(int start, int end) {
+  Future<List<int>> getRange(int start, int end) async {
     return bytes.sublist(start, end);
   }
 
   @override
-  int get length => bytes.length;
+  Future<int> get length async => bytes.length;
 
   @override
-  bool exists() {
+  Future<bool> exists() async {
     return bytes != null && bytes.isNotEmpty;
   }
 }

--- a/library/lib/src/core/network_input.dart
+++ b/library/lib/src/core/network_input.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'package:http/http.dart' as http;
+import 'package:image_size_getter/src/core/input.dart';
+
+class NetworkInput extends ImageInput {
+  NetworkInput(String url) {
+    var uri = Uri.parse(url);
+    var request = http.Request('GET', uri);
+    _response = _client.send(request);
+  }
+
+  http.Client _client = http.Client();
+  Stream<List<int>> _stream;
+  Future<http.StreamedResponse> _response;
+  List<int> data = List();
+  Future<Uint8List> get bytes async {
+    if (_stream == null) {
+      _stream = (await _response).stream.asBroadcastStream();
+    }
+    await _stream.forEach((element) {
+      data.addAll(element);
+    });
+    _client.close();
+    return Uint8List.fromList(data);
+  }
+
+  @override
+  Future<bool> exists() async {
+    return (await _response).statusCode == 200;
+  }
+
+  @override
+  Future<List<int>> getRange(int start, int end) async {
+    if (_stream == null) {
+      _stream = (await _response).stream.asBroadcastStream();
+      _stream.listen((event) {}, onDone: () {
+        _client.close();
+      });
+    }
+    while (data.length < end) {
+      data.addAll(await _stream.first);
+    }
+    return data.sublist(start, end);
+  }
+
+  @override
+  Future<int> get length async {
+    return (await _response).contentLength;
+  }
+}

--- a/library/lib/src/decoder/decoder.dart
+++ b/library/lib/src/decoder/decoder.dart
@@ -1,7 +1,7 @@
 import '../core/size.dart';
 
 abstract class ImageDecoder {
-  Size get size;
+  Future<Size> get size;
 
   int convertRadix16ToInt(List<int> list, {bool reverse = false}) {
     final sb = StringBuffer();

--- a/library/lib/src/decoder/gif_decoder.dart
+++ b/library/lib/src/decoder/gif_decoder.dart
@@ -9,9 +9,9 @@ class GifDecoder extends ImageDecoder {
   GifDecoder(this.input);
 
   @override
-  Size get size {
-    final widthList = input.getRange(6, 8);
-    final heightList = input.getRange(8, 10);
+  Future<Size> get size async {
+    final widthList = await input.getRange(6, 8);
+    final heightList = await input.getRange(8, 10);
 
     final width = convertRadix16ToInt(widthList, reverse: true);
     final height = convertRadix16ToInt(heightList, reverse: true);

--- a/library/lib/src/decoder/jpeg_decoder.dart
+++ b/library/lib/src/decoder/jpeg_decoder.dart
@@ -10,19 +10,19 @@ class JpegDecoder extends ImageDecoder {
   JpegDecoder(this.input);
 
   @override
-  Size get size {
+  Future<Size> get size async {
     int start = 2;
     BlockEntity block;
 
     while (true) {
-      block = getBlockInfo(start);
+      block = await getBlockInfo(start);
       if (block == null) {
         return Size(-1, -1);
       }
 
       if (block.type == 0xC0 || block.type == 0xC2) {
-        final widthList = input.getRange(start + 7, start + 9);
-        final heightList = input.getRange(start + 5, start + 7);
+        final widthList = await input.getRange(start + 7, start + 9);
+        final heightList = await input.getRange(start + 5, start + 7);
         final width = convertRadix16ToInt(widthList);
         final height = convertRadix16ToInt(heightList);
         return Size(width, height);
@@ -41,15 +41,15 @@ class JpegDecoder extends ImageDecoder {
     return int.tryParse(sb.toString(), radix: 16);
   }
 
-  BlockEntity getBlockInfo(int blackStart) {
+  Future<BlockEntity> getBlockInfo(int blackStart) async {
     try {
-      final blockInfoList = input.getRange(blackStart, blackStart + 4);
+      final blockInfoList = await input.getRange(blackStart, blackStart + 4);
 
       if (blockInfoList[0] != 0xFF) {
         return null;
       }
 
-      final radix16List = input.getRange(blackStart + 2, blackStart + 4);
+      final radix16List = await input.getRange(blackStart + 2, blackStart + 4);
       final blockLength = convertRadix16ToInt(radix16List) + 2;
       final typeInt = blockInfoList[1];
 

--- a/library/lib/src/decoder/png_decoder.dart
+++ b/library/lib/src/decoder/png_decoder.dart
@@ -8,9 +8,9 @@ class PngDecoder extends ImageDecoder {
 
   PngDecoder(this.input);
 
-  Size get size {
-    final widthList = input.getRange(0x10, 0x14);
-    final heightList = input.getRange(0x14, 0x18);
+  Future<Size> get size async {
+    final widthList = await input.getRange(0x10, 0x14);
+    final heightList = await input.getRange(0x14, 0x18);
 
     final width = convertRadix16ToInt(widthList);
     final height = convertRadix16ToInt(heightList);

--- a/library/lib/src/decoder/webp_decoder.dart
+++ b/library/lib/src/decoder/webp_decoder.dart
@@ -9,16 +9,16 @@ class WebpDecoder extends ImageDecoder {
   WebpDecoder(this.input);
 
   @override
-  Size get size {
+  Future<Size> get size async {
     final widthList = input.getRange(0x1a, 0x1c);
     final heightList = input.getRange(0x1c, 0x1e);
-    final width = convertRadix16ToInt(widthList, reverse: true);
-    final height = convertRadix16ToInt(heightList, reverse: true);
+    final width = convertRadix16ToInt(await widthList, reverse: true);
+    final height = convertRadix16ToInt(await heightList, reverse: true);
     return Size(width, height);
   }
 
   Future<bool> isLossy() async {
-    final v8Tag = input.getRange(12, 16);
+    final v8Tag = await input.getRange(12, 16);
     return v8Tag[3] == 0x20;
   }
 }

--- a/library/lib/src/image_size_getter.dart
+++ b/library/lib/src/image_size_getter.dart
@@ -32,12 +32,16 @@ class ImageSizeGetter {
     final length = await input.length;
 
     final start = await input.getRange(0, 8);
-    final end = await input.getRange(length - 12, length);
     const eq = IterableEquality();
-    if (eq.equals(start, _PngHeaders.sig) && eq.equals(end, _PngHeaders.iend)) {
+    if (input.runtimeType != NetworkInput) {
+      final end = await input.getRange(length - 12, length);
+      if (eq.equals(start, _PngHeaders.sig) &&
+          eq.equals(end, _PngHeaders.iend)) {
+        return true;
+      }
+    } else if (eq.equals(start, _PngHeaders.sig)) {
       return true;
     }
-
     return false;
   }
 
@@ -59,10 +63,13 @@ class ImageSizeGetter {
     final length = await input.length;
 
     final sizeStart = await input.getRange(0, 6);
-    final sizeEnd = await input.getRange(length - 1, length);
-
-    return eq.equals(sizeStart, _GifHeaders.start) &&
-        eq.equals(sizeEnd, _GifHeaders.end);
+    if (input.runtimeType != NetworkInput) {
+      final sizeEnd = await input.getRange(length - 1, length);
+      return eq.equals(sizeStart, _GifHeaders.start) &&
+          eq.equals(sizeEnd, _GifHeaders.end);
+    } else {
+      return eq.equals(sizeStart, _GifHeaders.start);
+    }
   }
 
   static Future<Size> getSize(ImageInput input) async {

--- a/library/lib/src/image_size_getter.dart
+++ b/library/lib/src/image_size_getter.dart
@@ -9,28 +9,28 @@ import 'package:image_size_getter/src/decoder/webp_decoder.dart';
 export 'core/input.dart';
 
 class ImageSizeGetter {
-  static bool isJpg(ImageInput input) {
-    if (input == null || !input.exists()) {
+  static Future<bool> isJpg(ImageInput input) async {
+    if (input == null || !await input.exists()) {
       return false;
     }
 
     const start = [0xFF, 0xD8];
     const end = [0xFF, 0xD9];
 
-    final length = input.length;
-    final startList = input.getRange(0, 2);
-    final endList = input.getRange(length - 2, length);
+    final length = await input.length;
+    final startList = await input.getRange(0, 2);
+    final endList = await input.getRange(length - 2, length);
 
     const eq = ListEquality();
 
     return eq.equals(start, startList) && eq.equals(end, endList);
   }
 
-  static bool isPng(ImageInput input) {
-    final length = input.length;
+  static Future<bool> isPng(ImageInput input) async {
+    final length = await input.length;
 
-    final start = input.getRange(0, 8);
-    final end = input.getRange(length - 12, length);
+    final start = await input.getRange(0, 8);
+    final end = await input.getRange(length - 12, length);
     const eq = IterableEquality();
     if (eq.equals(start, _PngHeaders.sig) && eq.equals(end, _PngHeaders.iend)) {
       return true;
@@ -39,9 +39,9 @@ class ImageSizeGetter {
     return false;
   }
 
-  static bool isWebp(ImageInput input) {
-    final sizeStart = input.getRange(0, 4);
-    final sizeEnd = input.getRange(8, 12);
+  static Future<bool> isWebp(ImageInput input) async {
+    final sizeStart = await input.getRange(0, 4);
+    final sizeEnd = await input.getRange(8, 12);
 
     const eq = ListEquality();
 
@@ -52,28 +52,28 @@ class ImageSizeGetter {
     return false;
   }
 
-  static bool isGif(ImageInput input) {
+  static Future<bool> isGif(ImageInput input) async {
     const eq = ListEquality();
-    final length = input.length;
+    final length = await input.length;
 
-    final sizeStart = input.getRange(0, 6);
-    final sizeEnd = input.getRange(length - 1, length);
+    final sizeStart = await input.getRange(0, 6);
+    final sizeEnd = await input.getRange(length - 1, length);
 
     return eq.equals(sizeStart, _GifHeaders.start) &&
         eq.equals(sizeEnd, _GifHeaders.end);
   }
 
-  static Size getSize(ImageInput input) {
-    if (isJpg(input)) {
+  static Future<Size> getSize(ImageInput input) async {
+    if (await isJpg(input)) {
       return JpegDecoder(input).size;
     }
-    if (isPng(input)) {
+    if (await isPng(input)) {
       return PngDecoder(input).size;
     }
-    if (isWebp(input)) {
+    if (await isWebp(input)) {
       return WebpDecoder(input).size;
     }
-    if (isGif(input)) {
+    if (await isGif(input)) {
       return GifDecoder(input).size;
     }
     return Size.zero;

--- a/library/lib/src/image_size_getter.dart
+++ b/library/lib/src/image_size_getter.dart
@@ -15,15 +15,17 @@ class ImageSizeGetter {
     }
 
     const start = [0xFF, 0xD8];
-    const end = [0xFF, 0xD9];
-
-    final length = await input.length;
     final startList = await input.getRange(0, 2);
-    final endList = await input.getRange(length - 2, length);
-
     const eq = ListEquality();
 
-    return eq.equals(start, startList) && eq.equals(end, endList);
+    if (input.runtimeType != NetworkInput) {
+      const end = [0xFF, 0xD9];
+      final length = await input.length;
+      final endList = await input.getRange(length - 2, length);
+      return eq.equals(start, startList) && eq.equals(end, endList);
+    } else {
+      return eq.equals(start, startList);
+    }
   }
 
   static Future<bool> isPng(ImageInput input) async {

--- a/library/pubspec.yaml
+++ b/library/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   collection: ^1.14.12
   hashcodes: ^1.0.0
+  http: ^0.12.2
 #  path: ^1.6.0
 
 dev_dependencies:


### PR DESCRIPTION
Loading big images over the network is slow, but the dimensions of an image can be determined with just the first few bytes.
In a scenario where the aspect ratio of an image retrieved over the network is not known beforehand, this allows to determine the final layout earlier. 

Fetching images over the network is by nature asynchronous. To accommodate this, all APIs of this libraries have been made `async` in this pull request.

Moreover, a convenient `NetworkInput` class has been added, that abstracts the response stream.  