### PR TITLE
fix: remove debug value print calls from `jpeg_decoder`

### DIFF
--- a/library/lib/src/decoder/impl/jpeg_decoder.dart
+++ b/library/lib/src/decoder/impl/jpeg_decoder.dart
@@ -36,7 +36,6 @@ class JpegDecoder extends BaseDecoder with SimpleTypeValidator {
         final exifOrientation = _getOrientation(app1BlockData);
         if (exifOrientation != null) {
           orientation = exifOrientation;
-          print('Orientation: $orientation');
         }
       }
 
@@ -78,14 +77,13 @@ class JpegDecoder extends BaseDecoder with SimpleTypeValidator {
         final exifOrientation = _getOrientation(app1BlockData);
         if (exifOrientation != null) {
           orientation = exifOrientation;
-          print('Orientation: $orientation');
         }
       }
 
       if (block.type == 0xC0 || block.type == 0xC2) {
         final widthList = await input.getRange(start + 7, start + 9);
         final heightList = await input.getRange(start + 5, start + 7);
-        final orientation = (await input.getRange(start + 9, start + 10))[0];
+        orientation = (await input.getRange(start + 9, start + 10))[0];
         return _getSize(widthList, heightList, orientation);
       } else {
         start += block.length;


### PR DESCRIPTION
while using version `2.1.0` to process a bunch of JPG image files, I kept seeing output in my terminal with `Orientation: 1`, but I could not figure out where it was coming from...

digging a little deeper, I discovered two `print()` commands causing this in the `jpeg_decoder.dart` library file, specifically [here](https://github.com/CaiJingLong/dart_image_size_getter/blob/a52b007ea34755b1d7123d666478c9e5dfd1e207/library/lib/src/decoder/impl/jpeg_decoder.dart#L39) and [here](https://github.com/CaiJingLong/dart_image_size_getter/blob/a52b007ea34755b1d7123d666478c9e5dfd1e207/library/lib/src/decoder/impl/jpeg_decoder.dart#L81).

after "fixing" the line `81` (by removing `print()` call), I noticed that the `orientation` variable definition on line `64` was reporting as "unused"... but simply removing the `final` keyword from the re-assignment of this variable on line `88` cleared that up.

I've forked and modified this project locally for my own usage, I'll 