### PR TITLE
fix: remove end bytes check for jpeg

### DIFF
--- a/packages/image_size_getter/lib/src/decoder/impl/jpeg_decoder.dart
+++ b/packages/image_size_getter/lib/src/decoder/impl/jpeg_decoder.dart
@@ -205,7 +205,7 @@ class JpegDecoder extends BaseDecoder with SimpleTypeValidator {
 
 class _JpegInfo with SimpleFileHeaderAndFooter {
   static const start = [0xFF, 0xD8];
-  static const end = [0xFF, 0xD9];
+  static const end = <int>[];
 
   @override
   List<int> get endBytes => end;


### PR DESCRIPTION
The JPEG standard only defines a JPEG data stream. That is what goes between the SOI and EOI markets. Anything outside that is outside JPEG.